### PR TITLE
chore(bench): add criterion as dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["mathematics", "finance", "data-structures"]
 readme = "README.md"
 
 [dependencies]
-rust_decimal = { version = "1.40", features = ["maths"] }
+rust_decimal = { version = "1.41", features = ["maths"] }
 rust_decimal_macros = "1.40"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -21,7 +21,7 @@ utoipa = { version = "5.4", features = ["decimal"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ utoipa = { version = "5.4", features = ["decimal"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- Adds `criterion = { version = "0.5", features = ["html_reports"] }` under `[dev-dependencies]` in `Cargo.toml`.
- Prerequisite for the benchmark harness introduced in #6/#7/#8.
- No runtime, public-API, or feature-flag impact.

## Scope note

Originally issue #5 also added `[[bench]]` entries. Those were moved to #6/#7/#8 so each entry lands together with its bench file and `cargo bench --no-run` stays green on every PR.

## Test plan

- [x] `cargo build --all-features` — clean
- [x] `cargo test --all-features` — 172 unit + 14 integration + 16 doctests, 0 failed
- [x] `cargo test --no-default-features` — 0 failed
- [x] `cargo test --features non-zero` — 0 failed
- [x] `make pre-push` — green (fmt, clippy, tests, readme, doc)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

## Semver impact

Patch-level. Dev-dependencies are invisible to downstream consumers.

Closes #5