### PR TITLE
bump: 0.4.0 -> 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-14
+
 ### Added
 
 - Benchmark harness based on [Criterion](https://docs.rs/criterion) with three

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "positive"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Joaquín Béjar García <jb@taunais.com>"]
 description = "A type-safe wrapper for guaranteed positive decimal values"


### PR DESCRIPTION
## Summary

Version bump to 0.4.1 to ship the M1 benchmark harness.

- Cargo.toml: 0.4.0 → 0.4.1.
- CHANGELOG.md: moves the benchmark harness entry under `[0.4.1] - 2026-04-14`.

## Semver impact

Patch release. All changes in this cycle are dev-only (benches, dev-deps, CHANGELOG).

## Test plan

- [x] `make pre-push` — green.