### PR TITLE
fix: clippy approx_constant + bump 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-14
+
+### Fixed
+
+- Replace `3.14_f64` literal in `benches/conversion.rs` with `3.25_f64` so
+  CI lint passes under clippy 1.94.0 (`approx_constant` is deny-by-default
+  and flagged the literal as an approximation of `f64::consts::PI`).
+
 ## [0.4.1] - 2026-04-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "positive"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Joaquín Béjar García <jb@taunais.com>"]
 description = "A type-safe wrapper for guaranteed positive decimal values"

--- a/benches/conversion.rs
+++ b/benches/conversion.rs
@@ -19,7 +19,7 @@ fn bench_from_primitive(c: &mut Criterion) {
     let d = dec!(9.99);
     let mut g = c.benchmark_group("conv/from_primitive");
     g.bench_function("new_f64", |bencher| {
-        bencher.iter(|| black_box(Positive::new(black_box(3.14_f64))))
+        bencher.iter(|| black_box(Positive::new(black_box(3.25_f64))))
     });
     g.bench_function("try_from_i64", |bencher| {
         bencher.iter(|| black_box(Positive::try_from(black_box(42_i64))))
@@ -28,7 +28,7 @@ fn bench_from_primitive(c: &mut Criterion) {
         bencher.iter(|| black_box(Positive::try_from(black_box(42_u64))))
     });
     g.bench_function("try_from_f64", |bencher| {
-        bencher.iter(|| black_box(Positive::try_from(black_box(3.14_f64))))
+        bencher.iter(|| black_box(Positive::try_from(black_box(3.25_f64))))
     });
     g.bench_function("try_from_usize", |bencher| {
         bencher.iter(|| black_box(Positive::try_from(black_box(100_usize))))


### PR DESCRIPTION
## Context

v0.4.1 was published before all CI checks settled. The Lint job failed on main with clippy 1.94.0's `approx_constant` denying `3.14_f64` in `benches/conversion.rs` (local pre-push had passed; my local clippy did not catch it but CI is stricter in this case).

## Summary

- `benches/conversion.rs`: replace `3.14_f64` with `3.25_f64` (not a constant approximation).
- `Cargo.toml`: version 0.4.1 → 0.4.2.
- `CHANGELOG.md`: new `[0.4.2]` section with the Fixed entry.

## Test plan

- [x] `make lint-fix pre-push` — zero errors, zero warnings.
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean.
- [x] `cargo test --all-features` / `--no-default-features` / `--features non-zero` — all green.
- [x] Bench compile unaffected.

## Semver impact

Patch release. No public API or runtime changes.