### PR TITLE
perf(build): add [profile.release] with thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,11 @@ harness = false
 [[bench]]
 name = "format_serde"
 harness = false
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+opt-level = 3
+debug = false
+strip = true
+# panic = "abort"   # intentionally omitted (see doc/performance-improvement-plan.md § 0)


### PR DESCRIPTION
## Summary

Adds an explicit `[profile.release]` to `Cargo.toml`:

```toml
[profile.release]
lto = "thin"
codegen-units = 1
opt-level = 3
debug = false
strip = true
# panic = "abort"   # intentionally omitted (see doc/performance-improvement-plan.md § 0)
```

## Scope note on impact

Library `[profile.release]` does **not** propagate to downstream consumers — it only affects `cargo build --release` / `cargo bench` on this crate. Effects land in CI, docs.rs, and local bench runs.

## LTO selection: `thin` vs `fat`

The original plan prescribed `lto = "fat"`. Empirical benches against the v0.4.0 baseline showed that fat LTO introduced a large regression on `serde/from_str/fractional` (+75%). Switching to `lto = "thin"` preserves most of the gains with only a borderline regression there.

## Benchmark deltas (thin LTO vs v0.4.0 baseline, statistically significant p < 0.05)

| Benchmark | Δ |
|-----------|---|
| arith/positive/sub | −28% |
| arith/positive/div | −9% |
| arith/positive/add | +19% |
| arith/positive/mul | +10% |
| round_clamp/clamp | −30% |
| is_multiple_of | −33% |
| conv/\* | −15% to −70% |
| sub_variants/\* | −16% to −22% |
| serde/from_str/fractional | +8% |

Most arith/f64 and math ops are within noise. Net positive across the suite; regressions are small absolute deltas at sub-5ns scale where LTO inlining decisions matter.

## Test plan

- [x] `cargo build --release` — clean.
- [x] `cargo test --all-features` — 165+14+16, 0 failed.
- [x] `cargo test --no-default-features` — 172+17+16, 0 failed.
- [x] `cargo test --features non-zero` — 165+14+16, 0 failed.
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean.
- [x] `make lint-fix pre-push` — green, zero warnings.
- [x] Benchmarks run (data above).

## Semver impact

None. Library profile does not propagate to consumers.

Closes #10