### PR TITLE
refactor(positive): repr(transparent) + derive Eq/Ord

### DIFF
--- a/src/positive.rs
+++ b/src/positive.rs
@@ -29,7 +29,8 @@ use std::str::FromStr;
 ///
 /// When the `non-zero` feature is enabled, the value must be strictly
 /// greater than zero.
-#[derive(PartialEq, Clone, Copy, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Positive(pub Decimal);
 
@@ -1029,28 +1030,6 @@ impl Div<&Decimal> for Positive {
 impl PartialOrd<Decimal> for Positive {
     fn partial_cmp(&self, other: &Decimal) -> Option<Ordering> {
         self.0.partial_cmp(other)
-    }
-}
-
-impl PartialOrd for Positive {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-
-    fn le(&self, other: &Self) -> bool {
-        self.0 <= other.0
-    }
-
-    fn ge(&self, other: &Self) -> bool {
-        self.0 >= other.0
-    }
-}
-
-impl Eq for Positive {}
-
-impl Ord for Positive {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or(Ordering::Equal)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `#[repr(transparent)]` to `Positive` (rule 23).
- Reorders derives to `Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash` per rule 30.
- Drops the redundant manual `impl Eq`, `impl PartialOrd`, and `impl Ord` blocks — now covered by derives. `Decimal::Ord` is total, so the derived `Ord` is equivalent to (and cleaner than) the previous `partial_cmp().unwrap_or(Equal)` approach.
- Keeps manual `impl PartialOrd<Decimal> for Positive` (cross-type comparison; not derivable).
- `Debug` remains a manual impl to preserve `Positive::INFINITY` rendering.

## Test plan

- [x] `cargo test --all-features` — 165+14+16, 0 failed.
- [x] `cargo test --no-default-features` — 172+17+16, 0 failed.
- [x] `cargo test --features non-zero` — 165+14+16, 0 failed.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

None. The field is already `pub Decimal`; adding `#[repr(transparent)]` tightens the layout guarantee without changing semantics. Adding `Eq/PartialOrd/Ord` derives is additive (these trait impls already existed manually). The field privatization is tracked separately in #12 and deferred.

Closes #11