### PR TITLE
refactor(positive)!: privatize inner Decimal field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ not yet finalised; do not rely on any intermediate state.
 
 - `[profile.release]` with thin LTO, single codegen-unit, `opt-level = 3`,
   `strip = true`, and `debug = false` (#10).
+- `#[repr(transparent)]` on `Positive` (#11).
+- Derived `Eq`, `PartialOrd`, `Ord` on `Positive` with the canonical derive
+  ordering (#11). Manual impls removed.
+
+### Changed
+
+- **BREAKING:** the inner `Decimal` field of `Positive` is now private (#12).
+  Use `Positive::to_dec()` or `Decimal::from(positive)` to read the
+  underlying value. Migration for pattern-matching / destructuring is not
+  available; use the accessor.
 
 ## [0.4.2] - 2026-04-14
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -21,157 +21,157 @@ use rust_decimal_macros::dec;
 ///
 /// This constant is not available when the `non-zero` feature is enabled.
 #[cfg(not(feature = "non-zero"))]
-pub const ZERO: Positive = Positive(Decimal::ZERO);
+pub const ZERO: Positive = Positive::from_decimal_const(Decimal::ZERO);
 
 /// A value of one represented as a `Positive` value.
-pub const ONE: Positive = Positive(Decimal::ONE);
+pub const ONE: Positive = Positive::from_decimal_const(Decimal::ONE);
 
 /// A value of two represented as a `Positive` value.
-pub const TWO: Positive = Positive(Decimal::TWO);
+pub const TWO: Positive = Positive::from_decimal_const(Decimal::TWO);
 
 /// A value of three represented as a `Positive` value.
-pub const THREE: Positive = Positive(dec!(3));
+pub const THREE: Positive = Positive::from_decimal_const(dec!(3));
 
 /// A value of four represented as a `Positive` value.
-pub const FOUR: Positive = Positive(dec!(4));
+pub const FOUR: Positive = Positive::from_decimal_const(dec!(4));
 
 /// A value of five represented as a `Positive` value.
-pub const FIVE: Positive = Positive(dec!(5));
+pub const FIVE: Positive = Positive::from_decimal_const(dec!(5));
 
 /// A value of six represented as a `Positive` value.
-pub const SIX: Positive = Positive(dec!(6));
+pub const SIX: Positive = Positive::from_decimal_const(dec!(6));
 
 /// A value of seven represented as a `Positive` value.
-pub const SEVEN: Positive = Positive(dec!(7));
+pub const SEVEN: Positive = Positive::from_decimal_const(dec!(7));
 
 /// A value of eight represented as a `Positive` value.
-pub const EIGHT: Positive = Positive(dec!(8));
+pub const EIGHT: Positive = Positive::from_decimal_const(dec!(8));
 
 /// A value of nine represented as a `Positive` value.
-pub const NINE: Positive = Positive(dec!(9));
+pub const NINE: Positive = Positive::from_decimal_const(dec!(9));
 
 /// A value of ten represented as a `Positive` value.
-pub const TEN: Positive = Positive(Decimal::TEN);
+pub const TEN: Positive = Positive::from_decimal_const(Decimal::TEN);
 
 // =============================================================================
 // Multiples of 5 (15-95)
 // =============================================================================
 
 /// A value of fifteen represented as a `Positive` value.
-pub const FIFTEEN: Positive = Positive(dec!(15));
+pub const FIFTEEN: Positive = Positive::from_decimal_const(dec!(15));
 
 /// A value of twenty represented as a `Positive` value.
-pub const TWENTY: Positive = Positive(dec!(20));
+pub const TWENTY: Positive = Positive::from_decimal_const(dec!(20));
 
 /// A value of twenty-five represented as a `Positive` value.
-pub const TWENTY_FIVE: Positive = Positive(dec!(25));
+pub const TWENTY_FIVE: Positive = Positive::from_decimal_const(dec!(25));
 
 /// A value of thirty represented as a `Positive` value.
-pub const THIRTY: Positive = Positive(dec!(30));
+pub const THIRTY: Positive = Positive::from_decimal_const(dec!(30));
 
 /// A value of thirty-five represented as a `Positive` value.
-pub const THIRTY_FIVE: Positive = Positive(dec!(35));
+pub const THIRTY_FIVE: Positive = Positive::from_decimal_const(dec!(35));
 
 /// A value of forty represented as a `Positive` value.
-pub const FORTY: Positive = Positive(dec!(40));
+pub const FORTY: Positive = Positive::from_decimal_const(dec!(40));
 
 /// A value of forty-five represented as a `Positive` value.
-pub const FORTY_FIVE: Positive = Positive(dec!(45));
+pub const FORTY_FIVE: Positive = Positive::from_decimal_const(dec!(45));
 
 /// A value of fifty represented as a `Positive` value.
-pub const FIFTY: Positive = Positive(dec!(50));
+pub const FIFTY: Positive = Positive::from_decimal_const(dec!(50));
 
 /// A value of fifty-five represented as a `Positive` value.
-pub const FIFTY_FIVE: Positive = Positive(dec!(55));
+pub const FIFTY_FIVE: Positive = Positive::from_decimal_const(dec!(55));
 
 /// A value of sixty represented as a `Positive` value.
-pub const SIXTY: Positive = Positive(dec!(60));
+pub const SIXTY: Positive = Positive::from_decimal_const(dec!(60));
 
 /// A value of sixty-five represented as a `Positive` value.
-pub const SIXTY_FIVE: Positive = Positive(dec!(65));
+pub const SIXTY_FIVE: Positive = Positive::from_decimal_const(dec!(65));
 
 /// A value of seventy represented as a `Positive` value.
-pub const SEVENTY: Positive = Positive(dec!(70));
+pub const SEVENTY: Positive = Positive::from_decimal_const(dec!(70));
 
 /// A value of seventy-five represented as a `Positive` value.
-pub const SEVENTY_FIVE: Positive = Positive(dec!(75));
+pub const SEVENTY_FIVE: Positive = Positive::from_decimal_const(dec!(75));
 
 /// A value of eighty represented as a `Positive` value.
-pub const EIGHTY: Positive = Positive(dec!(80));
+pub const EIGHTY: Positive = Positive::from_decimal_const(dec!(80));
 
 /// A value of eighty-five represented as a `Positive` value.
-pub const EIGHTY_FIVE: Positive = Positive(dec!(85));
+pub const EIGHTY_FIVE: Positive = Positive::from_decimal_const(dec!(85));
 
 /// A value of ninety represented as a `Positive` value.
-pub const NINETY: Positive = Positive(dec!(90));
+pub const NINETY: Positive = Positive::from_decimal_const(dec!(90));
 
 /// A value of ninety-five represented as a `Positive` value.
-pub const NINETY_FIVE: Positive = Positive(dec!(95));
+pub const NINETY_FIVE: Positive = Positive::from_decimal_const(dec!(95));
 
 // =============================================================================
 // Multiples of 100 (100-900)
 // =============================================================================
 
 /// A value of one hundred represented as a `Positive` value.
-pub const HUNDRED: Positive = Positive(Decimal::ONE_HUNDRED);
+pub const HUNDRED: Positive = Positive::from_decimal_const(Decimal::ONE_HUNDRED);
 
 /// A value of two hundred represented as a `Positive` value.
-pub const TWO_HUNDRED: Positive = Positive(dec!(200));
+pub const TWO_HUNDRED: Positive = Positive::from_decimal_const(dec!(200));
 
 /// A value of three hundred represented as a `Positive` value.
-pub const THREE_HUNDRED: Positive = Positive(dec!(300));
+pub const THREE_HUNDRED: Positive = Positive::from_decimal_const(dec!(300));
 
 /// A value of four hundred represented as a `Positive` value.
-pub const FOUR_HUNDRED: Positive = Positive(dec!(400));
+pub const FOUR_HUNDRED: Positive = Positive::from_decimal_const(dec!(400));
 
 /// A value of five hundred represented as a `Positive` value.
-pub const FIVE_HUNDRED: Positive = Positive(dec!(500));
+pub const FIVE_HUNDRED: Positive = Positive::from_decimal_const(dec!(500));
 
 /// A value of six hundred represented as a `Positive` value.
-pub const SIX_HUNDRED: Positive = Positive(dec!(600));
+pub const SIX_HUNDRED: Positive = Positive::from_decimal_const(dec!(600));
 
 /// A value of seven hundred represented as a `Positive` value.
-pub const SEVEN_HUNDRED: Positive = Positive(dec!(700));
+pub const SEVEN_HUNDRED: Positive = Positive::from_decimal_const(dec!(700));
 
 /// A value of eight hundred represented as a `Positive` value.
-pub const EIGHT_HUNDRED: Positive = Positive(dec!(800));
+pub const EIGHT_HUNDRED: Positive = Positive::from_decimal_const(dec!(800));
 
 /// A value of nine hundred represented as a `Positive` value.
-pub const NINE_HUNDRED: Positive = Positive(dec!(900));
+pub const NINE_HUNDRED: Positive = Positive::from_decimal_const(dec!(900));
 
 // =============================================================================
 // Multiples of 1000 (1000-10000)
 // =============================================================================
 
 /// A value of one thousand represented as a `Positive` value.
-pub const THOUSAND: Positive = Positive(Decimal::ONE_THOUSAND);
+pub const THOUSAND: Positive = Positive::from_decimal_const(Decimal::ONE_THOUSAND);
 
 /// A value of two thousand represented as a `Positive` value.
-pub const TWO_THOUSAND: Positive = Positive(dec!(2000));
+pub const TWO_THOUSAND: Positive = Positive::from_decimal_const(dec!(2000));
 
 /// A value of three thousand represented as a `Positive` value.
-pub const THREE_THOUSAND: Positive = Positive(dec!(3000));
+pub const THREE_THOUSAND: Positive = Positive::from_decimal_const(dec!(3000));
 
 /// A value of four thousand represented as a `Positive` value.
-pub const FOUR_THOUSAND: Positive = Positive(dec!(4000));
+pub const FOUR_THOUSAND: Positive = Positive::from_decimal_const(dec!(4000));
 
 /// A value of five thousand represented as a `Positive` value.
-pub const FIVE_THOUSAND: Positive = Positive(dec!(5000));
+pub const FIVE_THOUSAND: Positive = Positive::from_decimal_const(dec!(5000));
 
 /// A value of six thousand represented as a `Positive` value.
-pub const SIX_THOUSAND: Positive = Positive(dec!(6000));
+pub const SIX_THOUSAND: Positive = Positive::from_decimal_const(dec!(6000));
 
 /// A value of seven thousand represented as a `Positive` value.
-pub const SEVEN_THOUSAND: Positive = Positive(dec!(7000));
+pub const SEVEN_THOUSAND: Positive = Positive::from_decimal_const(dec!(7000));
 
 /// A value of eight thousand represented as a `Positive` value.
-pub const EIGHT_THOUSAND: Positive = Positive(dec!(8000));
+pub const EIGHT_THOUSAND: Positive = Positive::from_decimal_const(dec!(8000));
 
 /// A value of nine thousand represented as a `Positive` value.
-pub const NINE_THOUSAND: Positive = Positive(dec!(9000));
+pub const NINE_THOUSAND: Positive = Positive::from_decimal_const(dec!(9000));
 
 /// A value of ten thousand represented as a `Positive` value.
-pub const TEN_THOUSAND: Positive = Positive(dec!(10000));
+pub const TEN_THOUSAND: Positive = Positive::from_decimal_const(dec!(10000));
 
 // =============================================================================
 // Mathematical Constants
@@ -179,11 +179,11 @@ pub const TEN_THOUSAND: Positive = Positive(dec!(10000));
 
 /// The mathematical constant π (pi) represented as a `Positive` value.
 /// Approximately 3.14159265358979323846.
-pub const PI: Positive = Positive(Decimal::PI);
+pub const PI: Positive = Positive::from_decimal_const(Decimal::PI);
 
 /// The mathematical constant e (Euler's number) represented as a `Positive` value.
 /// Approximately 2.71828182845904523536.
-pub const E: Positive = Positive(Decimal::E);
+pub const E: Positive = Positive::from_decimal_const(Decimal::E);
 
 // =============================================================================
 // Special Values
@@ -194,7 +194,7 @@ pub const E: Positive = Positive(Decimal::E);
 pub const EPSILON: Decimal = dec!(1e-16);
 
 /// Represents the maximum positive value possible (effectively infinity).
-pub const INFINITY: Positive = Positive(Decimal::MAX);
+pub const INFINITY: Positive = Positive::from_decimal_const(Decimal::MAX);
 
 /// Number of days in a year.
-pub const DAYS_IN_A_YEAR: Positive = Positive(dec!(365.0));
+pub const DAYS_IN_A_YEAR: Positive = Positive::from_decimal_const(dec!(365.0));

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -32,7 +32,7 @@ use std::str::FromStr;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct Positive(pub Decimal);
+pub struct Positive(Decimal);
 
 /// Returns whether the given decimal value satisfies the positivity constraint.
 ///
@@ -553,6 +553,15 @@ impl Positive {
     /// ```
     #[must_use]
     pub const unsafe fn new_unchecked(value: Decimal) -> Self {
+        Positive(value)
+    }
+
+    /// Crate-private const constructor used exclusively by `crate::constants`
+    /// to define `Positive` constants in `const` context. The invariant is
+    /// enforced by the callers: every constant in `crate::constants` is a
+    /// strictly non-negative literal (or `>0` under the `non-zero` feature).
+    #[must_use]
+    pub(crate) const fn from_decimal_const(value: Decimal) -> Self {
         Positive(value)
     }
 }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE.** Rule 40 requires the inner field of `Positive` to be private to defend the invariant. This PR makes it private. Targets the 0.5.0 release.

- `src/positive.rs`: `pub struct Positive(pub Decimal)` → `pub struct Positive(Decimal)`.
- `src/positive.rs`: adds `pub(crate) const fn from_decimal_const(Decimal) -> Self`, used exclusively by `crate::constants` to keep constants const-evaluable without unsafe surface.
- `src/constants.rs`: replace the 51 `Positive(...)` literal constructions with `Positive::from_decimal_const(...)`. The safety invariant holds: every constant in the file is a strictly non-negative literal (or `>0` under `non-zero`).
- `CHANGELOG.md`: breaking-change entry documenting the migration (`positive.0` → `positive.to_dec()` / `Decimal::from(positive)`).

## Semver impact

Breaking. Requires 0.5.0 major bump — already in place (#43).

## Test plan

- [x] `cargo test --all-features` — 165+14+16 passing.
- [x] `cargo test --no-default-features` — 172+17+16 passing.
- [x] `cargo test --features non-zero` — 165+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

Closes #12