### PR TITLE
perf(error): #[cold] #[inline(never)] on PositiveError constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ not yet finalised; do not rely on any intermediate state.
 - `#[repr(transparent)]` on `Positive` (#11).
 - Derived `Eq`, `PartialOrd`, `Ord` on `Positive` with the canonical derive
   ordering (#11). Manual impls removed.
+- `#[cold] #[inline(never)]` on every `PositiveError` constructor and on
+  the `From<&str>` / `From<String>` impls (#13). Keeps error-formatting
+  code out of hot call sites.
 
 ### Changed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,8 @@ impl PositiveError {
     /// # Returns
     ///
     /// A new `PositiveError::InvalidValue` instance
+    #[cold]
+    #[inline(never)]
     #[must_use]
     pub fn invalid_value(value: f64, reason: &str) -> Self {
         PositiveError::InvalidValue {
@@ -137,6 +139,8 @@ impl PositiveError {
     /// # Returns
     ///
     /// A new `PositiveError::ArithmeticError` instance
+    #[cold]
+    #[inline(never)]
     #[must_use]
     pub fn arithmetic_error(operation: &str, reason: &str) -> Self {
         PositiveError::ArithmeticError {
@@ -156,6 +160,8 @@ impl PositiveError {
     /// # Returns
     ///
     /// A new `PositiveError::ConversionError` instance
+    #[cold]
+    #[inline(never)]
     #[must_use]
     pub fn conversion_error(from_type: &str, to_type: &str, reason: &str) -> Self {
         PositiveError::ConversionError {
@@ -176,6 +182,8 @@ impl PositiveError {
     /// # Returns
     ///
     /// A new `PositiveError::OutOfBounds` instance
+    #[cold]
+    #[inline(never)]
     #[must_use]
     pub fn out_of_bounds(value: f64, min: f64, max: f64) -> Self {
         PositiveError::OutOfBounds { value, min, max }
@@ -191,6 +199,8 @@ impl PositiveError {
     /// # Returns
     ///
     /// A new `PositiveError::InvalidPrecision` instance
+    #[cold]
+    #[inline(never)]
     #[must_use]
     pub fn invalid_precision(precision: i32, reason: &str) -> Self {
         PositiveError::InvalidPrecision {
@@ -201,12 +211,16 @@ impl PositiveError {
 }
 
 impl From<&str> for PositiveError {
+    #[cold]
+    #[inline(never)]
     fn from(s: &str) -> Self {
         PositiveError::Other(s.to_string())
     }
 }
 
 impl From<String> for PositiveError {
+    #[cold]
+    #[inline(never)]
     fn from(s: String) -> Self {
         PositiveError::Other(s)
     }


### PR DESCRIPTION
## Summary

Applies `#[cold] #[inline(never)]` (plus the pre-existing `#[must_use]`) to every `PositiveError` constructor and to the `From<&str>` / `From<String>` impls per rule 20.

## Changes

- `src/error.rs`: annotations added to `invalid_value`, `arithmetic_error`, `conversion_error`, `out_of_bounds`, `invalid_precision`, and the two `From` impls.
- `CHANGELOG.md`: entry under 0.5.0.

## Semver impact

None. Attribute changes only; no signature or behavior change.

## Test plan

- [x] `cargo test --all-features` / `--features non-zero` — 165+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

Closes #13