### PR TITLE
refactor(positive): #[must_use] audit on fallible constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ not yet finalised; do not rely on any intermediate state.
   `from_decimal_const`, every `From`/`Into`/`PartialEq`/`PartialOrd`, and
   every `Add`/`Sub`/`Mul`/`Div`/`AddAssign`/`MulAssign`/`Neg` impl for
   `Positive` (both sides).
+- `#[must_use]` on the remaining public constructors and checked
+  arithmetic methods that were missing it (#15): `Positive::new`,
+  `Positive::new_decimal`, `Positive::checked_sub`, `Positive::checked_div`.
 
 ### Changed
 

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -185,6 +185,7 @@ impl Positive {
     ///
     /// Without the `non-zero` feature, values >= 0 are accepted.
     /// With the `non-zero` feature, only values > 0 are accepted.
+    #[must_use = "constructor returns a Result; ignoring the Positive discards a validated invariant"]
     pub fn new(value: f64) -> Result<Self, PositiveError> {
         let dec = Decimal::from_f64(value);
         match dec {
@@ -206,6 +207,7 @@ impl Positive {
     ///
     /// Without the `non-zero` feature, values >= 0 are accepted.
     /// With the `non-zero` feature, only values > 0 are accepted.
+    #[must_use = "constructor returns a Result; ignoring the Positive discards a validated invariant"]
     pub fn new_decimal(value: Decimal) -> Result<Self, PositiveError> {
         if is_valid_positive_value(value) {
             Ok(Positive(value))
@@ -493,6 +495,7 @@ impl Positive {
     }
 
     /// Checked subtraction that returns Result instead of panicking.
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the overflow/underflow error"]
     pub fn checked_sub(&self, rhs: &Self) -> Result<Self, PositiveError> {
         Positive::new_decimal(self.0 - rhs.0)
     }
@@ -512,6 +515,7 @@ impl Positive {
     }
 
     /// Checked division that returns Result instead of panicking.
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the division-by-zero error"]
     pub fn checked_div(&self, rhs: &Self) -> Result<Self, PositiveError> {
         if rhs.is_zero() {
             Err(PositiveError::arithmetic_error(


### PR DESCRIPTION
## Summary

Adds `#[must_use]` with descriptive messages to every `Result`-returning public constructor / checked-arithmetic method that was missing the attribute (rule 9):

- `Positive::new`
- `Positive::new_decimal`
- `Positive::checked_sub`
- `Positive::checked_div`

Descriptive messages are necessary because `Result` itself is `#[must_use]` — plain `#[must_use]` on a `Result`-returning function triggers `clippy::double_must_use` and fails the `-D warnings` CI.

## Scope note

A Python sweep over `src/` confirmed these were the only four public functions returning non-`()` / non-`Self` without `#[must_use]`. Everything else was already compliant after #14.

## Test plan

- [x] `cargo test --all-features` — 165+14+16 passing.
- [x] `cargo test --no-default-features` — 172+17+16 passing.
- [x] `cargo test --features non-zero` — 165+14+16 passing.
- [x] `make lint-fix pre-push` — clean, zero warnings.

## Semver impact

None.

Closes #15