### PR TITLE
fix(positive): From<Positive> for usize without f64 round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ not yet finalised; do not rely on any intermediate state.
   arithmetic methods that were missing it (#15): `Positive::new`,
   `Positive::new_decimal`, `Positive::checked_sub`, `Positive::checked_div`.
 
+### Fixed
+
+- `From<Positive> for usize` now routes through `Decimal::to_u64()`
+  instead of `Decimal::to_f64() as usize`, preserving precision for
+  large integer values (#16). The observable signature is unchanged;
+  fractional values still truncate toward zero as before.
+
 ### Changed
 
 - **BREAKING:** the inner `Decimal` field of `Positive` is now private (#12).

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -619,9 +619,14 @@ impl From<Positive> for f64 {
 }
 
 impl From<Positive> for usize {
+    /// Converts the underlying `Decimal` to `usize` via `to_u64`.
+    ///
+    /// Returns `0` on overflow or when the value is not representable as
+    /// `u64`. For fallible, non-lossy conversion callers should prefer
+    /// matching on `Positive::to_u64_checked()`.
     #[inline]
     fn from(value: Positive) -> Self {
-        value.0.to_f64().unwrap_or(0.0) as usize
+        value.to_dec().to_u64().unwrap_or(0) as usize
     }
 }
 

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -738,6 +738,22 @@ fn test_from_positive_to_usize() {
 }
 
 #[test]
+fn test_from_positive_to_usize_truncates_fractional() {
+    // The conversion goes through `to_u64`, which truncates toward zero.
+    let p = pos_or_panic!(42.9);
+    let u: usize = p.into();
+    assert_eq!(u, 42);
+}
+
+#[test]
+fn test_from_positive_to_usize_large_value() {
+    use rust_decimal_macros::dec;
+    let p = positive::Positive::new_decimal(dec!(1000000)).expect("valid");
+    let u: usize = p.into();
+    assert_eq!(u, 1_000_000);
+}
+
+#[test]
 fn test_f64_partial_eq_ref_positive() {
     let p = pos_or_panic!(5.0);
     assert!(5.0 == &p);


### PR DESCRIPTION
## Summary

- `src/positive.rs`: `impl From<Positive> for usize` now uses `value.to_dec().to_u64().unwrap_or(0) as usize` instead of the old `to_f64().unwrap_or(0.0) as usize`. Preserves precision for large integer values (rule 44 — `Decimal` storage, avoid `f64` hops).
- `tests/positive_tests.rs`: new tests covering fractional truncation and large-integer values.
- `CHANGELOG.md`: Fixed entry under 0.5.0.

## Behavior

| Input | Old result | New result |
|-------|-----------|-----------|
| `42.0` | `42` | `42` |
| `42.9` | `42` (truncate) | `42` (truncate, same) |
| `1_000_000` | `1_000_000` | `1_000_000` |
| very large integer that exceeds `f64` precision | lossy | exact (up to `u64::MAX`) |
| value `> u64::MAX` | `0` | `0` |

## Test plan

- [x] `cargo test --all-features` — 167+14+16, 0 failed (+2 new tests).
- [x] `cargo test --no-default-features` — 174+17+16, 0 failed.
- [x] `cargo test --features non-zero` — 167+14+16, 0 failed.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

None. Public signature unchanged; behavior for valid values is identical or strictly more accurate.

## Follow-up

Consider adding `TryFrom<Positive> for usize` in v0.6.0 so the `unwrap_or(0)` silent fallback becomes a typed error.

Closes #16