### PR TITLE
perf(positive): add EPSILON_CMP constant and use it in eq impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ not yet finalised; do not rely on any intermediate state.
   arithmetic methods that were missing it (#15): `Positive::new`,
   `Positive::new_decimal`, `Positive::checked_sub`, `Positive::checked_div`.
 
+- `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
+  precomputed once so `PartialEq<Decimal> for Positive` and
+  `RelativeEq::default_max_relative` no longer multiply `EPSILON` by
+  `Decimal::from(100)` on every call.
+
 ### Fixed
 
 - `From<Positive> for usize` now routes through `Decimal::to_u64()`

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -193,6 +193,13 @@ pub const E: Positive = Positive::from_decimal_const(Decimal::E);
 /// Used for floating-point tolerance in equality checks.
 pub const EPSILON: Decimal = dec!(1e-16);
 
+/// Tolerance for `Positive == Decimal` comparisons.
+///
+/// Precomputed as `EPSILON * 100` (= `1e-14`). Declaring it as a `const`
+/// avoids the `Decimal::from(100)` construction and multiplication on
+/// every `PartialEq<Decimal>` call.
+pub const EPSILON_CMP: Decimal = dec!(1e-14);
+
 /// Represents the maximum positive value possible (effectively infinity).
 pub const INFINITY: Positive = Positive::from_decimal_const(Decimal::MAX);
 

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -6,7 +6,7 @@
 
 //! Core implementation of the Positive type.
 
-use crate::constants::EPSILON;
+use crate::constants::{EPSILON, EPSILON_CMP};
 use crate::error::PositiveError;
 use approx::{AbsDiffEq, RelativeEq};
 use num_traits::{FromPrimitive, Pow, ToPrimitive};
@@ -889,8 +889,9 @@ impl fmt::Debug for Positive {
 }
 
 impl PartialEq<Decimal> for Positive {
+    #[inline]
     fn eq(&self, other: &Decimal) -> bool {
-        (self.0 - *other).abs() <= EPSILON * Decimal::from(100)
+        (self.0 - *other).abs() <= EPSILON_CMP
     }
 }
 
@@ -1244,7 +1245,7 @@ impl AbsDiffEq for Positive {
 
 impl RelativeEq for Positive {
     fn default_max_relative() -> Self::Epsilon {
-        EPSILON * Decimal::from(100)
+        EPSILON_CMP
     }
 
     fn relative_eq(


### PR DESCRIPTION
## Summary

- `src/constants.rs`: new `pub const EPSILON_CMP: Decimal = dec!(1e-14)` (= `EPSILON * 100`, precomputed).
- `src/positive.rs`: `PartialEq<Decimal> for Positive` and `RelativeEq::default_max_relative` now use `EPSILON_CMP` directly.
- `#[inline]` added to `PartialEq<Decimal>::eq` for consistency with the rest of the eq impls.
- `CHANGELOG.md`: entry under 0.5.0.

## Semver impact

None. The observed tolerance is identical (`1e-14`); only the arithmetic is hoisted out.

## Test plan

- [x] `cargo test --all-features` / `--no-default-features` / `--features non-zero` — all green.
- [x] `make lint-fix pre-push` — clean.

Closes #17