### PR TITLE
feat(positive): overflow_panic / invariant_panic helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ not yet finalised; do not rely on any intermediate state.
   arithmetic methods that were missing it (#15): `Positive::new`,
   `Positive::new_decimal`, `Positive::checked_sub`, `Positive::checked_div`.
 
+- Crate-private panic helpers `overflow_panic` and `invariant_panic`
+  (#18). Both are `#[cold] #[inline(never)]` and provide a single
+  canonical panic site for arithmetic overflow and invariant violations,
+  which upcoming operator rewrites (#19–#22) will route through instead
+  of `.expect()`.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -75,6 +75,33 @@ pub fn is_positive<T: 'static>() -> bool {
     std::any::TypeId::of::<T>() == std::any::TypeId::of::<Positive>()
 }
 
+/// Panics with a uniform message when a `Positive` arithmetic operation
+/// overflows the underlying `Decimal` range.
+///
+/// Marked `#[cold]` and `#[inline(never)]` so the happy path stays lean.
+/// Callers will be wired in by the follow-up operator rewrites (#19–#22);
+/// `#[allow(dead_code)]` until then.
+#[cold]
+#[inline(never)]
+#[allow(dead_code)]
+pub(crate) fn overflow_panic(op: &'static str) -> ! {
+    panic!("Positive arithmetic overflow in {op}")
+}
+
+/// Panics with a uniform message when the result of a `Positive`
+/// arithmetic operation would violate the positivity invariant
+/// (negative, or zero under the `non-zero` feature).
+///
+/// Marked `#[cold]` and `#[inline(never)]` so the happy path stays lean.
+/// Callers will be wired in by the follow-up operator rewrites (#19–#22);
+/// `#[allow(dead_code)]` until then.
+#[cold]
+#[inline(never)]
+#[allow(dead_code)]
+pub(crate) fn invariant_panic(op: &'static str) -> ! {
+    panic!("Positive invariant broken in {op}: result would be non-positive")
+}
+
 impl Positive {
     // Re-export constants from the constants module for backward compatibility
     /// A zero value represented as a `Positive` value.


### PR DESCRIPTION
## Summary

Crate-private panic helpers in `src/positive.rs`:

```rust
#[cold] #[inline(never)] #[allow(dead_code)]
pub(crate) fn overflow_panic(op: &'static str) -> ! { panic!("...") }

#[cold] #[inline(never)] #[allow(dead_code)]
pub(crate) fn invariant_panic(op: &'static str) -> ! { panic!("...") }
```

Groundwork for #19–#22 which will route every operator panic through these. `#[allow(dead_code)]` until the first caller lands in #19.

## Semver impact

None. Crate-private.

## Test plan

- [x] `cargo test --all-features` — all green.
- [x] `make lint-fix pre-push` — clean.

Closes #18