### PR TITLE
perf(positive): Positive-Positive operators via checked_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ not yet finalised; do not rely on any intermediate state.
   canonical panic site for arithmetic overflow and invariant violations,
   which upcoming operator rewrites (#19–#22) will route through instead
   of `.expect()`.
+
+### Changed
+
+- All `Positive`⇄`Positive` operators (`Add`, `Sub`, `Mul`, `Div` for
+  both owned and `&` operands, plus `AddAssign`) now route through
+  `Decimal::checked_*` and the new panic helpers (#19) instead of raw
+  arithmetic or ad-hoc `panic!`. Overflow and invariant violations
+  surface via `overflow_panic` / `invariant_panic` with uniform
+  messages. Test panic expectations updated accordingly.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -79,11 +79,8 @@ pub fn is_positive<T: 'static>() -> bool {
 /// overflows the underlying `Decimal` range.
 ///
 /// Marked `#[cold]` and `#[inline(never)]` so the happy path stays lean.
-/// Callers will be wired in by the follow-up operator rewrites (#19–#22);
-/// `#[allow(dead_code)]` until then.
 #[cold]
 #[inline(never)]
-#[allow(dead_code)]
 pub(crate) fn overflow_panic(op: &'static str) -> ! {
     panic!("Positive arithmetic overflow in {op}")
 }
@@ -93,11 +90,8 @@ pub(crate) fn overflow_panic(op: &'static str) -> ! {
 /// (negative, or zero under the `non-zero` feature).
 ///
 /// Marked `#[cold]` and `#[inline(never)]` so the happy path stays lean.
-/// Callers will be wired in by the follow-up operator rewrites (#19–#22);
-/// `#[allow(dead_code)]` until then.
 #[cold]
 #[inline(never)]
-#[allow(dead_code)]
 pub(crate) fn invariant_panic(op: &'static str) -> ! {
     panic!("Positive invariant broken in {op}: result would be non-positive")
 }
@@ -1021,7 +1015,10 @@ impl Add for Positive {
     type Output = Positive;
     #[inline]
     fn add(self, other: Positive) -> Positive {
-        Positive(self.0 + other.0)
+        match self.0.checked_add(other.0) {
+            Some(v) => Positive(v),
+            None => overflow_panic("add"),
+        }
     }
 }
 
@@ -1029,11 +1026,14 @@ impl Sub for Positive {
     type Output = Positive;
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
-        let result = self.0 - rhs.0;
-        if result < Decimal::ZERO {
-            panic!("Resulting value must be positive");
-        } else {
+        let result = match self.0.checked_sub(rhs.0) {
+            Some(v) => v,
+            None => overflow_panic("sub"),
+        };
+        if is_valid_positive_value(result) {
             Positive(result)
+        } else {
+            invariant_panic("sub")
         }
     }
 }
@@ -1042,7 +1042,13 @@ impl Div for Positive {
     type Output = Positive;
     #[inline]
     fn div(self, other: Positive) -> Self::Output {
-        Positive(self.0 / other.0)
+        if other.0.is_zero() {
+            invariant_panic("div");
+        }
+        match self.0.checked_div(other.0) {
+            Some(v) => Positive(v),
+            None => overflow_panic("div"),
+        }
     }
 }
 
@@ -1050,7 +1056,13 @@ impl Div for &Positive {
     type Output = Positive;
     #[inline]
     fn div(self, other: &Positive) -> Self::Output {
-        Positive(self.0 / other.0)
+        if other.0.is_zero() {
+            invariant_panic("div");
+        }
+        match self.0.checked_div(other.0) {
+            Some(v) => Positive(v),
+            None => overflow_panic("div"),
+        }
     }
 }
 
@@ -1089,7 +1101,10 @@ impl Sub<&Decimal> for Positive {
 impl AddAssign for Positive {
     #[inline]
     fn add_assign(&mut self, other: Positive) {
-        self.0 += other.0;
+        match self.0.checked_add(other.0) {
+            Some(v) => self.0 = v,
+            None => overflow_panic("add_assign"),
+        }
     }
 }
 
@@ -1142,7 +1157,10 @@ impl Mul for Positive {
     type Output = Positive;
     #[inline]
     fn mul(self, other: Positive) -> Positive {
-        Positive(self.0 * other.0)
+        match self.0.checked_mul(other.0) {
+            Some(v) => Positive(v),
+            None => overflow_panic("mul"),
+        }
     }
 }
 

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -950,7 +950,7 @@ fn test_deserialize_negative_f64() {
 }
 
 #[test]
-#[should_panic(expected = "Resulting value must be positive")]
+#[should_panic(expected = "invariant broken in sub")]
 fn test_sub_panic() {
     let a = pos_or_panic!(3.0);
     let b = pos_or_panic!(5.0);


### PR DESCRIPTION
## Summary

Rewrites every `Positive`⇄`Positive` operator on the panic-on-overflow path to go through `Decimal::checked_*` plus the `#[cold]` panic helpers from #18, per rules 50 / 52 / 63.

### Operators rewritten

- `Add for Positive`, `Sub for Positive`, `Mul for Positive`, `Div for Positive`.
- `Div for &Positive`.
- `AddAssign for Positive`.

### Panic messages

- Overflow → `"Positive arithmetic overflow in {op}"`.
- Invariant violation (subtraction going negative or division by zero) → `"Positive invariant broken in {op}: result would be non-positive"`.

### Test fixup

- `tests/positive_tests.rs::test_sub_panic` now expects `"invariant broken in sub"` instead of the old `"Resulting value must be positive"` message.

### Follow-ups

- `#20` rewrites `Positive`⇄`Decimal` operators.
- `#21`/`#22` handle `f64` operators and checked `<Op><f64>` public API.

## Semver impact

Panic message strings are not part of the semver contract, and the panic semantics are unchanged (same conditions, still panic). The `checked_*` routing does not affect successful results.

## Test plan

- [x] `cargo test --all-features` / `--no-default-features` / `--features non-zero` — all green.
- [x] `make lint-fix pre-push` — clean.

Closes #19