### PR TITLE
perf(positive): drop Decimal<->f64 round-trip in <Op><f64>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ not yet finalised; do not rely on any intermediate state.
   `MulAssign`) now also route through `Decimal::checked_*` (#20). For
   `Positive`-returning ops the invariant is re-checked; for
   `Decimal`-returning ops only overflow is guarded.
+- `<Op><f64>` operators (`Add`, `Sub`, `Mul`, `Div` between `Positive`
+  and `f64`, plus `Div` for `&Positive`) no longer do a
+  `Decimal → f64 → operate → f64 → Decimal` round-trip (#21). They now
+  lift the `f64` rhs into `Decimal` once via `Decimal::from_f64` and
+  stay in `Decimal` through `checked_*`, improving precision and
+  avoiding the lossy hop.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -811,7 +811,16 @@ impl Mul<f64> for Positive {
     type Output = Positive;
     #[inline]
     fn mul(self, rhs: f64) -> Positive {
-        Positive::new(self.to_f64() * rhs).expect("Multiplication result must be positive")
+        let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("mul_f64"));
+        let result = match self.0.checked_mul(rhs_dec) {
+            Some(v) => v,
+            None => overflow_panic("mul_f64"),
+        };
+        if is_valid_positive_value(result) {
+            Positive(result)
+        } else {
+            invariant_panic("mul_f64")
+        }
     }
 }
 
@@ -819,7 +828,19 @@ impl Div<f64> for Positive {
     type Output = Positive;
     #[inline]
     fn div(self, rhs: f64) -> Positive {
-        Positive::new(self.to_f64() / rhs).expect("Division result must be positive")
+        let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("div_f64"));
+        if rhs_dec.is_zero() {
+            invariant_panic("div_f64");
+        }
+        let result = match self.0.checked_div(rhs_dec) {
+            Some(v) => v,
+            None => overflow_panic("div_f64"),
+        };
+        if is_valid_positive_value(result) {
+            Positive(result)
+        } else {
+            invariant_panic("div_f64")
+        }
     }
 }
 
@@ -827,7 +848,19 @@ impl Div<f64> for &Positive {
     type Output = Positive;
     #[inline]
     fn div(self, rhs: f64) -> Positive {
-        Positive::new(self.to_f64() / rhs).expect("Division result must be positive")
+        let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("div_f64"));
+        if rhs_dec.is_zero() {
+            invariant_panic("div_f64");
+        }
+        let result = match self.0.checked_div(rhs_dec) {
+            Some(v) => v,
+            None => overflow_panic("div_f64"),
+        };
+        if is_valid_positive_value(result) {
+            Positive(result)
+        } else {
+            invariant_panic("div_f64")
+        }
     }
 }
 
@@ -835,7 +868,16 @@ impl Sub<f64> for Positive {
     type Output = Positive;
     #[inline]
     fn sub(self, rhs: f64) -> Self::Output {
-        Positive::new(self.to_f64() - rhs).expect("Subtraction result must be positive")
+        let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("sub_f64"));
+        let result = match self.0.checked_sub(rhs_dec) {
+            Some(v) => v,
+            None => overflow_panic("sub_f64"),
+        };
+        if is_valid_positive_value(result) {
+            Positive(result)
+        } else {
+            invariant_panic("sub_f64")
+        }
     }
 }
 
@@ -843,7 +885,16 @@ impl Add<f64> for Positive {
     type Output = Positive;
     #[inline]
     fn add(self, rhs: f64) -> Self::Output {
-        Positive::new(self.to_f64() + rhs).expect("Addition result must be positive")
+        let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("add_f64"));
+        let result = match self.0.checked_add(rhs_dec) {
+            Some(v) => v,
+            None => overflow_panic("add_f64"),
+        };
+        if is_valid_positive_value(result) {
+            Positive(result)
+        } else {
+            invariant_panic("add_f64")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Rewrites `Add<f64>`, `Sub<f64>`, `Mul<f64>`, `Div<f64>` (for `Positive` and, where present, `&Positive`) to stay in `Decimal` throughout instead of doing `Decimal → f64 → operate → f64 → Decimal`.

### Before
```rust
Positive::new(self.to_f64() * rhs).expect("...")
```

### After
```rust
let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("mul_f64"));
let result = match self.0.checked_mul(rhs_dec) {
    Some(v) => v,
    None => overflow_panic("mul_f64"),
};
if is_valid_positive_value(result) { Positive(result) } else { invariant_panic("mul_f64") }
```

### Benefits
- No precision loss from the `f64` hop.
- Stays on the `Decimal` storage path (rule 44).
- Routes via `checked_*` (rule 50) and the shared panic helpers (rules 52 / 63).

## Test plan

- [x] `cargo test --all-features` / `--no-default-features` / `--features non-zero` — all green.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

None. Panic conditions (overflow, invariant violation) map 1:1 to the previous behavior; successful results are at least as accurate as before.

Closes #21