### PR TITLE
feat(positive): public checked_*_f64 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ not yet finalised; do not rely on any intermediate state.
   lift the `f64` rhs into `Decimal` once via `Decimal::from_f64` and
   stay in `Decimal` through `checked_*`, improving precision and
   avoiding the lossy hop.
+- Public checked `f64` arithmetic API on `Positive` (#22): every
+  panicking `<Op><f64>` operator now has a non-panicking
+  `Result<Positive, PositiveError>` counterpart:
+  `Positive::checked_add_f64`, `checked_sub_f64`, `checked_mul_f64`,
+  `checked_div_f64`. Required by rule 52 (checked equivalent must exist
+  for every panicking operator).
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -548,6 +548,91 @@ impl Positive {
         }
     }
 
+    /// Checked addition with an `f64`, returning a `Result` instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConversionError` if `rhs` cannot be represented as a
+    /// `Decimal` (e.g. NaN, `±inf`), an `ArithmeticError` on overflow, or
+    /// an `OutOfBounds` if the result would violate the positivity
+    /// invariant.
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the error"]
+    pub fn checked_add_f64(self, rhs: f64) -> Result<Positive, PositiveError> {
+        let rhs_dec = Decimal::from_f64(rhs).ok_or_else(|| {
+            PositiveError::conversion_error("f64", "Decimal", "value not representable as Decimal")
+        })?;
+        let result = self
+            .0
+            .checked_add(rhs_dec)
+            .ok_or_else(|| PositiveError::arithmetic_error("add_f64", "overflow"))?;
+        Positive::new_decimal(result)
+    }
+
+    /// Checked subtraction with an `f64`, returning a `Result` instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConversionError` if `rhs` cannot be represented as a
+    /// `Decimal`, an `ArithmeticError` on overflow, or an `OutOfBounds`
+    /// if the result would violate the positivity invariant.
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the error"]
+    pub fn checked_sub_f64(self, rhs: f64) -> Result<Positive, PositiveError> {
+        let rhs_dec = Decimal::from_f64(rhs).ok_or_else(|| {
+            PositiveError::conversion_error("f64", "Decimal", "value not representable as Decimal")
+        })?;
+        let result = self
+            .0
+            .checked_sub(rhs_dec)
+            .ok_or_else(|| PositiveError::arithmetic_error("sub_f64", "overflow"))?;
+        Positive::new_decimal(result)
+    }
+
+    /// Checked multiplication with an `f64`, returning a `Result` instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConversionError` if `rhs` cannot be represented as a
+    /// `Decimal`, an `ArithmeticError` on overflow, or an `OutOfBounds`
+    /// if the result would violate the positivity invariant (for example
+    /// when `rhs` is negative).
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the error"]
+    pub fn checked_mul_f64(self, rhs: f64) -> Result<Positive, PositiveError> {
+        let rhs_dec = Decimal::from_f64(rhs).ok_or_else(|| {
+            PositiveError::conversion_error("f64", "Decimal", "value not representable as Decimal")
+        })?;
+        let result = self
+            .0
+            .checked_mul(rhs_dec)
+            .ok_or_else(|| PositiveError::arithmetic_error("mul_f64", "overflow"))?;
+        Positive::new_decimal(result)
+    }
+
+    /// Checked division by an `f64`, returning a `Result` instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConversionError` if `rhs` cannot be represented as a
+    /// `Decimal`, an `ArithmeticError` on overflow or division by zero,
+    /// or an `OutOfBounds` if the result would violate the positivity
+    /// invariant (for example when `rhs` is negative).
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the error"]
+    pub fn checked_div_f64(self, rhs: f64) -> Result<Positive, PositiveError> {
+        let rhs_dec = Decimal::from_f64(rhs).ok_or_else(|| {
+            PositiveError::conversion_error("f64", "Decimal", "value not representable as Decimal")
+        })?;
+        if rhs_dec.is_zero() {
+            return Err(PositiveError::arithmetic_error(
+                "div_f64",
+                "division by zero",
+            ));
+        }
+        let result = self
+            .0
+            .checked_div(rhs_dec)
+            .ok_or_else(|| PositiveError::arithmetic_error("div_f64", "overflow"))?;
+        Positive::new_decimal(result)
+    }
+
     /// Checks whether the value is a multiple of another f64 value.
     #[must_use]
     pub fn is_multiple(&self, other: f64) -> bool {

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -1423,3 +1423,53 @@ fn test_decimal_add_ref_positive_impl() {
     let result = d + p;
     assert_eq!(result, dec!(8.0));
 }
+
+// ===== checked_*_f64 public API (issue #22) =====
+
+#[test]
+fn test_checked_add_f64_ok() {
+    let p = pos_or_panic!(5.0);
+    let result = p.checked_add_f64(2.5).expect("ok");
+    assert_eq!(result.to_f64(), 7.5);
+}
+
+#[test]
+fn test_checked_add_f64_nan_is_conversion_error() {
+    let p = pos_or_panic!(5.0);
+    let err = p.checked_add_f64(f64::NAN).unwrap_err();
+    assert!(matches!(
+        err,
+        positive::PositiveError::ConversionError { .. }
+    ));
+}
+
+#[test]
+fn test_checked_sub_f64_invariant_error() {
+    let p = pos_or_panic!(3.0);
+    let err = p.checked_sub_f64(5.0).unwrap_err();
+    assert!(matches!(err, positive::PositiveError::OutOfBounds { .. }));
+}
+
+#[test]
+fn test_checked_mul_f64_negative_is_invariant_error() {
+    let p = pos_or_panic!(5.0);
+    let err = p.checked_mul_f64(-2.0).unwrap_err();
+    assert!(matches!(err, positive::PositiveError::OutOfBounds { .. }));
+}
+
+#[test]
+fn test_checked_div_f64_zero_is_arithmetic_error() {
+    let p = pos_or_panic!(5.0);
+    let err = p.checked_div_f64(0.0).unwrap_err();
+    assert!(matches!(
+        err,
+        positive::PositiveError::ArithmeticError { .. }
+    ));
+}
+
+#[test]
+fn test_checked_div_f64_ok() {
+    let p = pos_or_panic!(10.0);
+    let result = p.checked_div_f64(4.0).expect("ok");
+    assert_eq!(result.to_f64(), 2.5);
+}


### PR DESCRIPTION
## Summary

Adds the non-panicking twins of every `<Op><f64>` operator (rule 52):

- `Positive::checked_add_f64`
- `Positive::checked_sub_f64`
- `Positive::checked_mul_f64`
- `Positive::checked_div_f64`

All four go through `Decimal::from_f64` + `Decimal::checked_*` + `Positive::new_decimal`, so failures surface as typed `PositiveError` variants:

| Failure | Variant |
|---------|---------|
| `rhs` is NaN / ±inf | `ConversionError` |
| overflow | `ArithmeticError` |
| division by zero | `ArithmeticError` |
| result is negative / zero under `non-zero` | `OutOfBounds` |

## Tests

Six new integration tests under `tests/positive_tests.rs` covering the happy path and each error variant.

## Test plan

- [x] `cargo test --all-features` — 173+14+16 passing (+6 new tests).
- [x] `cargo test --no-default-features` — 180+17+16 passing.
- [x] `cargo test --features non-zero` — 173+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

Additive. New public methods; no existing signatures changed.

Closes #22