### PR TITLE
feat(positive): document and apply Div rounding strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ not yet finalised; do not rely on any intermediate state.
   `Positive::checked_add_f64`, `checked_sub_f64`, `checked_mul_f64`,
   `checked_div_f64`. Required by rule 52 (checked equivalent must exist
   for every panicking operator).
+- Explicit `Div` rounding strategy (#23): `DIV_ROUNDING_STRATEGY` const
+  (banker's rounding / `MidpointNearestEven`) drives every `Div` impl
+  and `Positive::checked_div` / `checked_div_f64` via the crate-private
+  `round_div` helper. Callers who need a different strategy can use the
+  new `Positive::checked_div_with_strategy`. Rule 54.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -10,7 +10,7 @@ use crate::constants::{EPSILON, EPSILON_CMP};
 use crate::error::PositiveError;
 use approx::{AbsDiffEq, RelativeEq};
 use num_traits::{FromPrimitive, Pow, ToPrimitive};
-use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal::{Decimal, MathematicalOps, RoundingStrategy};
 use rust_decimal_macros::dec;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -73,6 +73,33 @@ fn min_bound() -> f64 {
 #[must_use]
 pub fn is_positive<T: 'static>() -> bool {
     std::any::TypeId::of::<T>() == std::any::TypeId::of::<Positive>()
+}
+
+/// Default rounding strategy used by every `Div` operator on `Positive`.
+///
+/// `Decimal` division is exact when the result fits in its 28-digit
+/// mantissa, but when it does not the operation must round. We pick
+/// banker's rounding (`MidpointNearestEven`) as the canonical strategy
+/// because it is statistically unbiased and matches IEEE-754 default
+/// behaviour for financial calculations. Callers needing a different
+/// strategy should use [`Positive::checked_div_with_strategy`].
+pub const DIV_ROUNDING_STRATEGY: RoundingStrategy = RoundingStrategy::MidpointNearestEven;
+
+/// Maximum decimal places preserved by division results.
+///
+/// `rust_decimal::Decimal` carries up to 28 digits of precision; rounding
+/// at that scale is effectively "keep full precision". This constant is
+/// used by every `Div` operator and by
+/// [`Positive::checked_div_with_strategy`].
+pub(crate) const DIV_SCALE: u32 = 28;
+
+/// Applies [`DIV_ROUNDING_STRATEGY`] to the result of a division.
+///
+/// Kept as a crate-private helper so every `Div` / `checked_div*`
+/// operator on `Positive` rounds through the same point.
+#[inline]
+pub(crate) fn round_div(result: Decimal) -> Decimal {
+    result.round_dp_with_strategy(DIV_SCALE, DIV_ROUNDING_STRATEGY)
 }
 
 /// Panics with a uniform message when a `Positive` arithmetic operation
@@ -536,6 +563,11 @@ impl Positive {
     }
 
     /// Checked division that returns Result instead of panicking.
+    ///
+    /// Uses [`DIV_ROUNDING_STRATEGY`] (banker's rounding) for any
+    /// rounding required by the result. Use
+    /// [`Positive::checked_div_with_strategy`] to select a different
+    /// strategy.
     #[must_use = "checked arithmetic returns a Result; ignoring it silences the division-by-zero error"]
     pub fn checked_div(&self, rhs: &Self) -> Result<Self, PositiveError> {
         if rhs.is_zero() {
@@ -544,8 +576,32 @@ impl Positive {
                 "division by zero",
             ))
         } else {
-            Ok(Positive(self.0 / rhs.0))
+            Ok(Positive(round_div(self.0 / rhs.0)))
         }
+    }
+
+    /// Checked division with an explicit rounding strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `ArithmeticError` on division by zero or overflow.
+    #[must_use = "checked arithmetic returns a Result; ignoring it silences the error"]
+    pub fn checked_div_with_strategy(
+        &self,
+        rhs: &Self,
+        strategy: RoundingStrategy,
+    ) -> Result<Self, PositiveError> {
+        if rhs.is_zero() {
+            return Err(PositiveError::arithmetic_error(
+                "division",
+                "division by zero",
+            ));
+        }
+        let result = self
+            .0
+            .checked_div(rhs.0)
+            .ok_or_else(|| PositiveError::arithmetic_error("division", "overflow"))?;
+        Ok(Positive(result.round_dp_with_strategy(DIV_SCALE, strategy)))
     }
 
     /// Checked addition with an `f64`, returning a `Result` instead of panicking.
@@ -630,7 +686,7 @@ impl Positive {
             .0
             .checked_div(rhs_dec)
             .ok_or_else(|| PositiveError::arithmetic_error("div_f64", "overflow"))?;
-        Positive::new_decimal(result)
+        Positive::new_decimal(round_div(result))
     }
 
     /// Checks whether the value is a multiple of another f64 value.
@@ -911,6 +967,10 @@ impl Mul<f64> for Positive {
 
 impl Div<f64> for Positive {
     type Output = Positive;
+    /// Divides by an `f64` using [`DIV_ROUNDING_STRATEGY`] (banker's
+    /// rounding) when rounding is required. For a different strategy
+    /// use [`Positive::checked_div_with_strategy`] on the lifted
+    /// `Decimal`.
     #[inline]
     fn div(self, rhs: f64) -> Positive {
         let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("div_f64"));
@@ -918,7 +978,7 @@ impl Div<f64> for Positive {
             invariant_panic("div_f64");
         }
         let result = match self.0.checked_div(rhs_dec) {
-            Some(v) => v,
+            Some(v) => round_div(v),
             None => overflow_panic("div_f64"),
         };
         if is_valid_positive_value(result) {
@@ -931,6 +991,8 @@ impl Div<f64> for Positive {
 
 impl Div<f64> for &Positive {
     type Output = Positive;
+    /// Divides a `&Positive` by an `f64` using [`DIV_ROUNDING_STRATEGY`]
+    /// (banker's rounding) when rounding is required.
     #[inline]
     fn div(self, rhs: f64) -> Positive {
         let rhs_dec = Decimal::from_f64(rhs).unwrap_or_else(|| invariant_panic("div_f64"));
@@ -938,7 +1000,7 @@ impl Div<f64> for &Positive {
             invariant_panic("div_f64");
         }
         let result = match self.0.checked_div(rhs_dec) {
-            Some(v) => v,
+            Some(v) => round_div(v),
             None => overflow_panic("div_f64"),
         };
         if is_valid_positive_value(result) {
@@ -1176,13 +1238,16 @@ impl Sub for Positive {
 
 impl Div for Positive {
     type Output = Positive;
+    /// Divides two `Positive` values using [`DIV_ROUNDING_STRATEGY`]
+    /// (banker's rounding) when rounding is required. For a different
+    /// strategy use [`Positive::checked_div_with_strategy`].
     #[inline]
     fn div(self, other: Positive) -> Self::Output {
         if other.0.is_zero() {
             invariant_panic("div");
         }
         match self.0.checked_div(other.0) {
-            Some(v) => Positive(v),
+            Some(v) => Positive(round_div(v)),
             None => overflow_panic("div"),
         }
     }
@@ -1190,13 +1255,15 @@ impl Div for Positive {
 
 impl Div for &Positive {
     type Output = Positive;
+    /// Divides two `&Positive` values using [`DIV_ROUNDING_STRATEGY`]
+    /// (banker's rounding) when rounding is required.
     #[inline]
     fn div(self, other: &Positive) -> Self::Output {
         if other.0.is_zero() {
             invariant_panic("div");
         }
         match self.0.checked_div(other.0) {
-            Some(v) => Positive(v),
+            Some(v) => Positive(round_div(v)),
             None => overflow_panic("div"),
         }
     }
@@ -1308,13 +1375,15 @@ impl MulAssign<Decimal> for Positive {
 
 impl Div<Decimal> for Positive {
     type Output = Positive;
+    /// Divides by a `Decimal` using [`DIV_ROUNDING_STRATEGY`] (banker's
+    /// rounding) when rounding is required.
     #[inline]
     fn div(self, rhs: Decimal) -> Positive {
         if rhs.is_zero() {
             invariant_panic("div_decimal");
         }
         let result = match self.0.checked_div(rhs) {
-            Some(v) => v,
+            Some(v) => round_div(v),
             None => overflow_panic("div_decimal"),
         };
         if is_valid_positive_value(result) {
@@ -1327,13 +1396,15 @@ impl Div<Decimal> for Positive {
 
 impl Div<&Decimal> for Positive {
     type Output = Positive;
+    /// Divides by a `&Decimal` using [`DIV_ROUNDING_STRATEGY`] (banker's
+    /// rounding) when rounding is required.
     #[inline]
     fn div(self, rhs: &Decimal) -> Self::Output {
         if rhs.is_zero() {
             invariant_panic("div_decimal");
         }
         let result = match self.0.checked_div(*rhs) {
-            Some(v) => v,
+            Some(v) => round_div(v),
             None => overflow_panic("div_decimal"),
         };
         if is_valid_positive_value(result) {

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -1473,3 +1473,61 @@ fn test_checked_div_f64_ok() {
     let result = p.checked_div_f64(4.0).expect("ok");
     assert_eq!(result.to_f64(), 2.5);
 }
+
+// ===== Div rounding strategy (issue #23) =====
+
+#[test]
+fn test_div_default_uses_bankers_rounding() {
+    use rust_decimal_macros::dec;
+    // 1 / 3 = 0.333...; banker's rounding at 28 dp gives the decimal
+    // truncated at that scale.
+    let a = positive::Positive::new_decimal(dec!(1)).expect("ok");
+    let b = positive::Positive::new_decimal(dec!(3)).expect("ok");
+    let r = a / b;
+    // Result must equal 1/3 rounded to 28 dp.
+    let expected = dec!(1) / dec!(3);
+    assert_eq!(
+        r.to_dec()
+            .round_dp_with_strategy(28, rust_decimal::RoundingStrategy::MidpointNearestEven),
+        expected.round_dp_with_strategy(28, rust_decimal::RoundingStrategy::MidpointNearestEven)
+    );
+}
+
+#[test]
+fn test_checked_div_with_strategy_ok() {
+    use rust_decimal_macros::dec;
+    let a = positive::Positive::new_decimal(dec!(7)).expect("ok");
+    let b = positive::Positive::new_decimal(dec!(2)).expect("ok");
+    let r = a
+        .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
+        .expect("ok");
+    assert_eq!(r.to_dec(), dec!(3.5));
+}
+
+#[test]
+fn test_checked_div_with_strategy_zero_divisor() {
+    use rust_decimal_macros::dec;
+    let a = positive::Positive::new_decimal(dec!(7)).expect("ok");
+    let b = positive::Positive::new_decimal(dec!(0)).unwrap_or(positive::Positive::ONE);
+    // Under default features b may be zero; under non-zero it's ONE.
+    #[cfg(not(feature = "non-zero"))]
+    {
+        let b = positive::Positive::new_decimal(dec!(0)).expect("ok");
+        let err = a
+            .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            positive::PositiveError::ArithmeticError { .. }
+        ));
+    }
+    #[cfg(feature = "non-zero")]
+    {
+        // Non-zero cannot construct zero; this branch is not reachable
+        // with a real zero, so we just sanity-check the positive path.
+        let r = a
+            .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
+            .expect("ok");
+        assert_eq!(r.to_dec(), dec!(7));
+    }
+}


### PR DESCRIPTION
## Summary

Makes the division rounding strategy explicit, documented, and overridable (rule 54).

### New public surface

- `DIV_ROUNDING_STRATEGY: RoundingStrategy` — canonical strategy used by every `Div` and `checked_div*` (banker's rounding, aka `MidpointNearestEven`).
- `Positive::checked_div_with_strategy(&self, rhs: &Self, strategy: RoundingStrategy) -> Result<Positive, PositiveError>` — per-call override.

### Under the hood

- `round_div(Decimal) -> Decimal` crate-private helper applies the strategy at a single point.
- Every `Div` impl returning `Positive` now routes through `round_div` after the `checked_div`: `Div for Positive`, `Div for &Positive`, `Div<f64> for Positive`, `Div<f64> for &Positive`, `Div<Decimal> for Positive`, `Div<&Decimal> for Positive`.
- `Positive::checked_div` and `Positive::checked_div_f64` both do the same.
- Doc comments on each `Div::div` describe the strategy and point at `checked_div_with_strategy` for overrides.

### Rationale

Banker's rounding is statistically unbiased, matches IEEE-754 defaults for financial calculations, and is what `rust_decimal::Decimal::round_dp_with_strategy` recommends for general-purpose arithmetic.

## Test plan

- [x] `cargo test --all-features` — 176+14+16 passing (+3 new tests).
- [x] `cargo test --no-default-features` — 183+17+16 passing.
- [x] `cargo test --features non-zero` — 176+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

Additive. New public items (`DIV_ROUNDING_STRATEGY`, `checked_div_with_strategy`). Existing `Div` results are now *explicitly* rounded at 28 dp with banker's rounding — this matches the behavior of `Decimal::/` in practice, so observable results are unchanged for any division whose exact result fits in 28 dp (i.e. almost all finite cases).

Closes #23