### PR TITLE
refactor(positive): Neg panic via invariant_panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ not yet finalised; do not rely on any intermediate state.
   and `Positive::checked_div` / `checked_div_f64` via the crate-private
   `round_div` helper. Callers who need a different strategy can use the
   new `Positive::checked_div_with_strategy`. Rule 54.
+- `Neg for Positive` now routes through `invariant_panic("neg")`
+  instead of a bespoke `panic!(...)` string (#24). Panic message is now
+  `"Positive invariant broken in neg: result would be non-positive"`;
+  `#[should_panic]` test updated accordingly.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -1424,9 +1424,13 @@ impl PartialOrd<Decimal> for Positive {
 
 impl Neg for Positive {
     type Output = Self;
+    /// Always panics — a `Positive` cannot be negated without violating
+    /// the invariant. Routed through [`invariant_panic`] for a uniform
+    /// panic message (`"Positive invariant broken in neg: result would
+    /// be non-positive"`).
     #[inline]
     fn neg(self) -> Self::Output {
-        panic!("Cannot negate a Positive value!");
+        invariant_panic("neg")
     }
 }
 

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -181,7 +181,7 @@ fn test_positive_decimal_floor() {
 }
 
 #[test]
-#[should_panic(expected = "Cannot negate a Positive value!")]
+#[should_panic(expected = "invariant broken in neg")]
 fn test_positive_decimal_neg() {
     let a = pos_or_panic!(1.0);
     let _ = -a;


### PR DESCRIPTION
## Summary

- `src/positive.rs`: `Neg::neg` for `Positive` no longer uses a bespoke `panic!(...)` string. It now calls `invariant_panic("neg")`, which routes through the shared `#[cold] #[inline(never)]` helper and produces the uniform `"Positive invariant broken in neg: result would be non-positive"` message.
- `tests/positive_tests.rs`: `test_positive_decimal_neg` updated to expect `"invariant broken in neg"`.

## Rationale

Consistency with the rest of the arithmetic operators after #19–#23. Rule 63 requires no `.unwrap()` / `.expect()` / ad-hoc panics in `src/` outside `#[cfg(test)]`.

## Semver impact

Panic message text changed; panic conditions unchanged. Message strings are not part of the semver contract.

## Test plan

- [x] `cargo test --all-features` — 176+14+16 passing.
- [x] `cargo test --no-default-features` — 183+17+16 passing.
- [x] `cargo test --features non-zero` — 176+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

Closes #24