### PR TITLE
docs(serde): keep manual impls; record #[serde(transparent)] decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ not yet finalised; do not rely on any intermediate state.
   formatting (#25). It now rounds the underlying `Decimal` directly
   via `round_dp`, preserving precision beyond the ~15 significant
   digits of `f64`.
+- Decision recorded for #26 (serde representation): the manual
+  `Serialize`/`Deserialize` impls are retained for 0.5.0. Migrating to
+  `#[serde(transparent)]` would switch the wire format from JSON
+  numbers (`42`, `12.345`, `f64::MAX` for infinity) to JSON strings
+  (`"42"`) because `rust_decimal`'s default serde representation is
+  string-based without the optional `serde-with-float` / equivalent
+  features. Documented in `src/positive.rs`; revisit in a future
+  major version if the numeric JSON shape is no longer required.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -1123,6 +1123,16 @@ impl PartialEq<Decimal> for Positive {
     }
 }
 
+// NOTE (#26): `#[serde(transparent)]` would delegate to `Decimal`'s
+// default `Serialize`/`Deserialize`, which emits a JSON string (e.g.
+// `"12.345"`). The manual impls below preserve a long-standing,
+// downstream-visible JSON contract:
+//   - `Positive::INFINITY` serialises to the literal `f64::MAX`.
+//   - integer-valued `Positive`s serialise as JSON integers (`42`).
+//   - fractional `Positive`s serialise as JSON numbers (`12.345`).
+// Switching to `#[serde(transparent)]` would change the wire format
+// and is therefore deferred. Duplicated validation inside the
+// deserialiser is removed separately in #27.
 impl Serialize for Positive {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
## Summary

Evaluated whether to switch `Positive` to `#[serde(transparent)]` (issue #26). **Decision: keep the manual impls for 0.5.0.**

### Rationale

`rust_decimal`'s default `Serialize`/`Deserialize` emits JSON strings (`"12.345"`). The manual impls we have today emit JSON numbers (`42`, `12.345`, `f64::MAX` for `INFINITY`). Any downstream consumer relying on the numeric wire format would break if we flipped to `#[serde(transparent)]`.

The duplicated positivity check inside the deserialiser is a separate concern and is cleaned up in #27.

### Deliverable

- Comment in `src/positive.rs` at the top of `impl Serialize for Positive` documenting the decision and listing the wire-format guarantees.
- `CHANGELOG.md` entry under 0.5.0 recording the decision.

## Semver impact

None. No code behaviour changes.

## Test plan

- [x] `make lint-fix pre-push` — clean.

Closes #26