### PR TITLE
perf(serde): single-pass validation in Positive visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ not yet finalised; do not rely on any intermediate state.
   string-based without the optional `serde-with-float` / equivalent
   features. Documented in `src/positive.rs`; revisit in a future
   major version if the numeric JSON shape is no longer required.
+- Deserialization visitor no longer double-validates the positivity
+  invariant (#27). `visit_i64`, `visit_u64`, and `visit_f64` used to
+  call `is_valid_positive_value` *and* `Positive::new_decimal`
+  (which re-checks the same invariant); now they call only
+  `new_decimal`. Error messages for negative/zero inputs now come from
+  `PositiveError::OutOfBounds` rather than the bespoke custom strings.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -1184,24 +1184,14 @@ impl<'de> Deserialize<'de> for Positive {
             where
                 E: serde::de::Error,
             {
-                let decimal = Decimal::from(value);
-                if !is_valid_positive_value(decimal) {
-                    Err(serde::de::Error::custom("Expected a positive integer"))
-                } else {
-                    Positive::new_decimal(decimal).map_err(serde::de::Error::custom)
-                }
+                Positive::new_decimal(Decimal::from(value)).map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                let decimal = Decimal::from(value);
-                if !is_valid_positive_value(decimal) {
-                    Err(serde::de::Error::custom("Expected a positive integer"))
-                } else {
-                    Positive::new_decimal(decimal).map_err(serde::de::Error::custom)
-                }
+                Positive::new_decimal(Decimal::from(value)).map_err(serde::de::Error::custom)
             }
 
             fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
@@ -1216,11 +1206,7 @@ impl<'de> Deserialize<'de> for Positive {
                 }
                 let decimal = Decimal::from_f64(value)
                     .ok_or_else(|| serde::de::Error::custom("Failed to convert f64 to Decimal"))?;
-                if !is_valid_positive_value(decimal) {
-                    Err(serde::de::Error::custom("Expected a positive float"))
-                } else {
-                    Positive::new_decimal(decimal).map_err(serde::de::Error::custom)
-                }
+                Positive::new_decimal(decimal).map_err(serde::de::Error::custom)
             }
         }
 


### PR DESCRIPTION
## Summary

`visit_i64`, `visit_u64`, and `visit_f64` in `impl<'de> Deserialize<'de> for Positive` previously validated the positivity invariant twice — once with `is_valid_positive_value` and again inside `Positive::new_decimal`. Removed the redundant first check so each visitor path goes through `new_decimal` once.

### Behavior change

Error *messages* for negative/zero inputs now come from `PositiveError::OutOfBounds` (e.g. `"Value -5 is out of bounds (min: 0, max: 1.7976931348623157e308)"`) instead of the bespoke `"Expected a positive integer"` / `"Expected a positive float"` strings. The error *type* routed through serde is the same (`serde::de::Error::custom`).

### Tests

Existing deserialisation tests for negative values already exercise the error path; no new tests required.

## Test plan

- [x] `cargo test --all-features` — 177+14+16 passing.
- [x] `cargo test --no-default-features` — 184+17+16 passing.
- [x] `cargo test --features non-zero` — 177+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

None on the type system. Error *message* text changed — not part of the semver contract.

Closes #27