### PR TITLE
feat(positive): is_multiple_of_dec and deprecate is_multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ not yet finalised; do not rely on any intermediate state.
   and calling `trim_end_matches('0').trim_end_matches('.')` (#28). Same
   output for every tested case (integer-valued, fractional,
   `Positive::INFINITY`, very large non-`i64` integers).
+- `Positive::is_multiple_of_dec(other: Decimal) -> bool` (#29) —
+  `Decimal`-native multiplicity check using `Decimal::checked_rem`.
+  Replaces the lossy `f64`-based path. `Positive::is_multiple(f64)` is
+  now `#[deprecated(since = "0.5.0")]`; existing callers continue to
+  work but emit a deprecation warning.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ let round2 = p.round_to(2);    // Round to 2 decimal places
 ```rust
 use positive::pos_or_panic;
 
+use rust_decimal_macros::dec;
 let p = pos_or_panic!(5.0);
 
 let is_zero = p.is_zero();                      // Check if zero
-let is_mult = p.is_multiple(2.0);               // Check if multiple of value
+let is_mult = p.is_multiple_of_dec(dec!(2));    // Check if multiple of value
 let clamped = p.clamp(pos_or_panic!(1.0), pos_or_panic!(10.0));   // Clamp between bounds
 let min_val = p.min(pos_or_panic!(3.0));                 // Minimum of two values
 let max_val = p.max(pos_or_panic!(3.0));                 // Maximum of two values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,10 +192,11 @@
 //! ```rust
 //! use positive::pos_or_panic;
 //!
+//! use rust_decimal_macros::dec;
 //! let p = pos_or_panic!(5.0);
 //!
 //! let is_zero = p.is_zero();                      // Check if zero
-//! let is_mult = p.is_multiple(2.0);               // Check if multiple of value
+//! let is_mult = p.is_multiple_of_dec(dec!(2));    // Check if multiple of value
 //! let clamped = p.clamp(pos_or_panic!(1.0), pos_or_panic!(10.0));   // Clamp between bounds
 //! let min_val = p.min(pos_or_panic!(3.0));                 // Minimum of two values
 //! let max_val = p.max(pos_or_panic!(3.0));                 // Maximum of two values

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -698,7 +698,16 @@ impl Positive {
         Positive::new_decimal(round_div(result))
     }
 
-    /// Checks whether the value is a multiple of another f64 value.
+    /// Checks whether the value is a multiple of another `f64` value.
+    ///
+    /// Prefer [`Positive::is_multiple_of_dec`] for full `Decimal`
+    /// precision — this variant lifts the value to `f64` and compares
+    /// against `f64::EPSILON`, which can misclassify values beyond the
+    /// ~15-digit precision of `f64`.
+    #[deprecated(
+        since = "0.5.0",
+        note = "use `is_multiple_of_dec` for Decimal-native precision"
+    )]
     #[must_use]
     pub fn is_multiple(&self, other: f64) -> bool {
         let value = self.to_f64();
@@ -707,6 +716,23 @@ impl Positive {
         }
         let remainder = value % other;
         remainder.abs() < f64::EPSILON || (other - remainder.abs()).abs() < f64::EPSILON
+    }
+
+    /// Checks whether the value is a multiple of a `Decimal` without
+    /// lifting to `f64`.
+    ///
+    /// Returns `false` when `other` is zero. Uses
+    /// [`Decimal::checked_rem`] so pathological inputs cannot panic.
+    #[inline]
+    #[must_use]
+    pub fn is_multiple_of_dec(&self, other: Decimal) -> bool {
+        if other.is_zero() {
+            return false;
+        }
+        self.0
+            .checked_rem(other)
+            .map(|r| r.is_zero())
+            .unwrap_or(false)
     }
 
     /// Checks whether the value is a multiple of another Positive value.

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -417,6 +417,7 @@ fn test_format_fixed_places() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_is_multiple() {
     let num = pos_or_panic!(10.0);
     assert!(num.is_multiple(2.0));
@@ -684,6 +685,7 @@ fn test_clamp_within_range() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_is_multiple_edge_cases() {
     // Test with a value that would produce non-finite result in modulo
     let value = pos_or_panic!(10.0);
@@ -1279,6 +1281,7 @@ fn test_debug_decimal_value() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_is_multiple_true_case() {
     let value = pos_or_panic!(10.0);
     assert!(value.is_multiple(2.0));
@@ -1287,12 +1290,14 @@ fn test_is_multiple_true_case() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_is_multiple_near_boundary() {
     let value = pos_or_panic!(9.999999999999998);
     assert!(value.is_multiple(1.0));
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_is_multiple_with_non_finite() {
     // Test is_multiple when value would produce non-finite result
     // Note: Positive::INFINITY is Decimal::MAX which is finite when converted to f64
@@ -1544,4 +1549,28 @@ fn test_format_fixed_places_preserves_decimal_precision() {
         formatted.contains("0123"),
         "expected precise tail, got {formatted}"
     );
+}
+
+#[test]
+fn test_is_multiple_of_dec_true() {
+    use rust_decimal_macros::dec;
+    let p = pos_or_panic!(15.0);
+    assert!(p.is_multiple_of_dec(dec!(3)));
+    assert!(p.is_multiple_of_dec(dec!(5)));
+    assert!(p.is_multiple_of_dec(dec!(1)));
+}
+
+#[test]
+fn test_is_multiple_of_dec_false() {
+    use rust_decimal_macros::dec;
+    let p = pos_or_panic!(15.0);
+    assert!(!p.is_multiple_of_dec(dec!(2)));
+    assert!(!p.is_multiple_of_dec(dec!(4)));
+}
+
+#[test]
+fn test_is_multiple_of_dec_zero_divisor() {
+    use rust_decimal_macros::dec;
+    let p = pos_or_panic!(15.0);
+    assert!(!p.is_multiple_of_dec(dec!(0)));
 }


### PR DESCRIPTION
## Summary

- Adds `Positive::is_multiple_of_dec(other: Decimal) -> bool` — `Decimal`-native multiplicity check via `Decimal::checked_rem`.
- Deprecates `Positive::is_multiple(f64)` via `#[deprecated(since = "0.5.0", note = "use is_multiple_of_dec for Decimal-native precision")]`. Still works, still tested, but emits a deprecation warning.

## Why

Rule 44 (`Decimal` storage only; avoid `f64` hops where avoidable) and rule 184 (no signature removal without a major bump — hence deprecation instead of removal).

## Test plan

- [x] 3 new tests: happy path, negative case, zero divisor.
- [x] 4 existing `test_is_multiple*` tests annotated `#[allow(deprecated)]` and still green.
- [x] `cargo test --all-features` — 180+14+16 passing.
- [x] `cargo test --no-default-features` — 187+17+16 passing.
- [x] `cargo test --features non-zero` — 180+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

Additive. `is_multiple` remains callable; new method is purely new surface.

Closes #29