### PR TITLE
perf(positive): is_multiple_of via checked_rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ not yet finalised; do not rely on any intermediate state.
   Replaces the lossy `f64`-based path. `Positive::is_multiple(f64)` is
   now `#[deprecated(since = "0.5.0")]`; existing callers continue to
   work but emit a deprecation warning.
+- `Positive::is_multiple_of(&Positive)` now uses `Decimal::checked_rem`
+  (#30) so pathological inputs that could previously panic under raw
+  `%` now return `false` instead. Observable behaviour for normal
+  inputs is unchanged.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -735,14 +735,24 @@ impl Positive {
             .unwrap_or(false)
     }
 
-    /// Checks whether the value is a multiple of another Positive value.
+    /// Checks whether the value is a multiple of another `Positive`
+    /// value.
+    ///
+    /// Returns `false` when `other` is zero. Uses
+    /// [`Decimal::checked_rem`] so pathological inputs cannot panic
+    /// (rule 50). The remainder is compared against [`EPSILON`] to
+    /// tolerate the tiny rounding artefacts `Decimal` can introduce at
+    /// the edge of its 28-digit mantissa.
+    #[inline]
     #[must_use]
     pub fn is_multiple_of(&self, other: &Positive) -> bool {
         if other.is_zero() {
             return false;
         }
-        let remainder = self.0 % other.0;
-        remainder.abs() < EPSILON
+        self.0
+            .checked_rem(other.0)
+            .map(|r| r.abs() < EPSILON)
+            .unwrap_or(false)
     }
 
     /// Creates a new `Positive` value without checking if the value is non-negative.


### PR DESCRIPTION
## Summary

`Positive::is_multiple_of(&Positive)` now uses `Decimal::checked_rem` instead of raw `%` (rule 50). Inputs that would overflow the raw operator now return `false` rather than panicking.

## Behaviour

- Normal inputs: unchanged. `r.abs() < EPSILON` comparison preserved.
- Edge inputs (near `Decimal::MAX` with pathological divisors): now return `false` instead of panicking.

## Test plan

- [x] `cargo test --all-features` — 180+14+16 passing.
- [x] `cargo test --no-default-features` — 187+17+16 passing.
- [x] `cargo test --features non-zero` — 180+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

## Semver impact

None. No API change; behaviour for well-formed inputs is identical.

Closes #30