### PR TITLE
docs(constants): document compile-time guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,11 @@ not yet finalised; do not rely on any intermediate state.
   (#30) so pathological inputs that could previously panic under raw
   `%` now return `false` instead. Observable behaviour for normal
   inputs is unchanged.
+- Audited `src/constants.rs` (#31): every `pub const` is built from
+  `dec!(...)` literals, `Decimal` associated constants, or
+  `Positive::from_decimal_const`. No runtime initialisation,
+  allocations, `OnceCell`, or `lazy_static` anywhere. Documented the
+  compile-time guarantee at the top of the module.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,22 @@
 //!
 //! This module provides commonly used numeric constants as `Positive` values,
 //! including integers, mathematical constants, and special values.
+//!
+//! # Compile-time evaluation
+//!
+//! Every `pub const` in this module is built from:
+//!
+//! 1. `rust_decimal_macros::dec!(...)` literals — expanded at compile
+//!    time into `Decimal` associated constants with no runtime cost.
+//! 2. `Decimal::ZERO` / `Decimal::ONE` / `Decimal::TWO` / `Decimal::TEN`
+//!    / `Decimal::MAX` — `const` items in `rust_decimal` itself.
+//! 3. `Positive::from_decimal_const(...)` — a `pub(crate) const fn`
+//!    crate-private wrapper that stores the value without revalidation
+//!    (safety upheld by the literal being non-negative).
+//!
+//! None of these involve runtime work, allocations, `OnceCell`,
+//! `lazy_static`, or floating-point conversion. Consumers can treat
+//! every constant as zero-cost at the point of use.
 
 use crate::Positive;
 use rust_decimal::Decimal;


### PR DESCRIPTION
## Summary

Completes the #31 audit. All 53 `pub const` in `src/constants.rs` are built from compile-time sources:

- `dec!(...)` literals (compile-time macro expansion).
- `Decimal::ZERO` / `Decimal::ONE` / `Decimal::TWO` / `Decimal::TEN` / `Decimal::MAX` (const items in `rust_decimal`).
- `Positive::from_decimal_const` (`pub(crate) const fn`, introduced in #12).

No runtime initialisation, no `OnceCell`, no `lazy_static`, no `f64` conversion. Documented the guarantee at the top of the module.

## Semver impact

None. Doc-only change.

## Test plan

- [x] `cargo test --all-features` — all green.
- [x] `make lint-fix pre-push` — clean.

Closes #31