### PR TITLE
docs(proposal): defer Option<Positive> niche optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@ not yet finalised; do not rely on any intermediate state.
   ladder for choosing between `new_decimal` / `new` / the macros /
   `new_unchecked`, and an explicit UB example. The function body is
   unchanged.
+- Evaluated niche optimisation for `Option<Positive>` (#33) and
+  **deferred**. `Decimal` carries no niche, so `Option<Positive>` pays
+  a discriminant byte today. A sibling `PositiveNonZero` type built on
+  `NonZeroU128` + scale would recover the niche but nothing in the
+  Criterion suites or downstream reports currently justifies the cost.
+  Full analysis lives in the local `doc/niche-optimization-proposal.md`
+  (not committed). Revisit once benchmarks or a concrete downstream
+  complaint demand it.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by


### PR DESCRIPTION
## Summary

Closes #33 with a **defer** decision.

### Why defer

- `Decimal` has no niche, so `Option<Positive>` currently pays a discriminant byte (~24 bytes total on x86-64).
- Recovering the niche would require either a sibling `PositiveNonZero` type (Option A) or a full layout pivot (Option B), both substantial engineering efforts.
- The current Criterion suites (`arith`, `conversion`, `format_serde`) do not exercise `Option<Positive>` and no downstream crate has reported a pain point.

### Where the full analysis lives

`doc/niche-optimization-proposal.md` — kept locally (the `doc/` tree is excluded from the repo via `.git/info/exclude` per the project's convention). Contents summarised in the CHANGELOG entry landed by this PR.

### Re-open triggers

- A Criterion bench showing `Option<Positive>` is > 2–3% of hot-path time.
- A concrete downstream use case that needs the niche.

## Semver impact

None. Decision record only.

## Test plan

- [x] `make lint-fix pre-push` — clean.

Closes #33