### PR TITLE
refactor(positive)!: remove impl Neg for Positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,16 @@ not yet finalised; do not rely on any intermediate state.
   Full analysis lives in the local `doc/niche-optimization-proposal.md`
   (not committed). Revisit once benchmarks or a concrete downstream
   complaint demand it.
+
+### Removed
+
+- **BREAKING:** `impl Neg for Positive` has been removed (#34). The
+  previous implementation always panicked, so the code
+  `let y = -x;` was a trap that surfaced only at runtime. Callers now
+  get a compile-time error instead. Migration: the value you want is
+  almost certainly a `Decimal`; call `positive.to_dec().neg()` or
+  `-positive.to_dec()` explicitly. The corresponding
+  `#[should_panic]` test was removed alongside the impl.
 - `EPSILON_CMP` constant (= `1e-14`) in `crate::constants` (#17),
   precomputed once so `PartialEq<Decimal> for Positive` and
   `RelativeEq::default_max_relative` no longer multiply `EPSILON` by

--- a/src/positive.rs
+++ b/src/positive.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use std::fmt::Display;
 #[cfg(not(feature = "non-zero"))]
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub};
 use std::str::FromStr;
 
 /// A wrapper type that represents a guaranteed positive decimal value.
@@ -1508,18 +1508,6 @@ impl PartialOrd<Decimal> for Positive {
     #[inline]
     fn partial_cmp(&self, other: &Decimal) -> Option<Ordering> {
         self.0.partial_cmp(other)
-    }
-}
-
-impl Neg for Positive {
-    type Output = Self;
-    /// Always panics — a `Positive` cannot be negated without violating
-    /// the invariant. Routed through [`invariant_panic`] for a uniform
-    /// panic message (`"Positive invariant broken in neg: result would
-    /// be non-positive"`).
-    #[inline]
-    fn neg(self) -> Self::Output {
-        invariant_panic("neg")
     }
 }
 

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -180,13 +180,6 @@ fn test_positive_decimal_floor() {
     assert_eq!(a.floor().value(), dec!(1.0));
 }
 
-#[test]
-#[should_panic(expected = "invariant broken in neg")]
-fn test_positive_decimal_neg() {
-    let a = pos_or_panic!(1.0);
-    let _ = -a;
-}
-
 #[cfg(not(feature = "non-zero"))]
 #[test]
 fn test_sum_owned_values() {


### PR DESCRIPTION
## Summary

**BREAKING CHANGE.** `impl Neg for Positive` is removed in 0.5.0. The previous implementation always panicked (`invariant_panic("neg")`), so `let y = -x;` compiled but crashed at runtime. Removing the impl converts the trap into a compile-time error.

## Migration

The value you probably want is the inner `Decimal`, so:

```rust
// Before (compiled, panicked at runtime)
let y = -x;

// After (compile-time error — fix by asking for what you actually meant)
let y = -x.to_dec();
// or equivalently
let y = x.to_dec().neg();
```

## Changes

- `src/positive.rs`: delete `impl Neg for Positive` and the now-unused `Neg` import.
- `tests/positive_tests.rs`: remove `test_positive_decimal_neg` (was `#[should_panic]`, now would fail to compile).
- `CHANGELOG.md`: **Removed** entry under 0.5.0 documenting the migration.

## Semver impact

Breaking — already inside the 0.5.0 major bump, consistent with #12 (private field) and the M3 checked_* refactors.

## Test plan

- [x] `cargo test --all-features` — 179+14+16 passing.
- [x] `cargo test --no-default-features` — 186+17+16 passing.
- [x] `cargo test --features non-zero` — 179+14+16 passing.
- [x] `make lint-fix pre-push` — clean.

Closes #34