### PR TITLE
fix(docs): re-export DIV_ROUNDING_STRATEGY and fix unused-var warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ mod positive;
 pub mod prelude;
 mod tests;
 pub use error::{PositiveError, PositiveResult};
-pub use positive::{Positive, is_positive, is_valid_positive_value};
+pub use positive::{DIV_ROUNDING_STRATEGY, Positive, is_positive, is_valid_positive_value};
 
 /// Re-export rust_decimal for convenience.
 pub use rust_decimal::Decimal;

--- a/tests/positive_tests.rs
+++ b/tests/positive_tests.rs
@@ -1502,32 +1502,33 @@ fn test_checked_div_with_strategy_ok() {
     assert_eq!(r.to_dec(), dec!(3.5));
 }
 
+#[cfg(not(feature = "non-zero"))]
 #[test]
 fn test_checked_div_with_strategy_zero_divisor() {
     use rust_decimal_macros::dec;
     let a = positive::Positive::new_decimal(dec!(7)).expect("ok");
-    let b = positive::Positive::new_decimal(dec!(0)).unwrap_or(positive::Positive::ONE);
-    // Under default features b may be zero; under non-zero it's ONE.
-    #[cfg(not(feature = "non-zero"))]
-    {
-        let b = positive::Positive::new_decimal(dec!(0)).expect("ok");
-        let err = a
-            .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            positive::PositiveError::ArithmeticError { .. }
-        ));
-    }
-    #[cfg(feature = "non-zero")]
-    {
-        // Non-zero cannot construct zero; this branch is not reachable
-        // with a real zero, so we just sanity-check the positive path.
-        let r = a
-            .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
-            .expect("ok");
-        assert_eq!(r.to_dec(), dec!(7));
-    }
+    let b = positive::Positive::new_decimal(dec!(0)).expect("ok");
+    let err = a
+        .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        positive::PositiveError::ArithmeticError { .. }
+    ));
+}
+
+#[cfg(feature = "non-zero")]
+#[test]
+fn test_checked_div_with_strategy_positive_divisor() {
+    use rust_decimal_macros::dec;
+    // Under `non-zero` a zero divisor cannot be constructed; exercise
+    // the non-zero happy path instead.
+    let a = positive::Positive::new_decimal(dec!(7)).expect("ok");
+    let b = positive::Positive::ONE;
+    let r = a
+        .checked_div_with_strategy(&b, rust_decimal::RoundingStrategy::ToZero)
+        .expect("ok");
+    assert_eq!(r.to_dec(), dec!(7));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Clears the last warnings before tagging v0.5.0.

### rustdoc: `DIV_ROUNDING_STRATEGY` private intra-doc link

`DIV_ROUNDING_STRATEGY` was `pub const` inside `mod positive` (private). The public `Div::div` and `Positive::checked_div*` doc comments linked to it via `[\`DIV_ROUNDING_STRATEGY\`]`, which triggered seven `rustdoc::private_intra_doc_links` warnings under `cargo doc --no-deps --document-private-items`. Re-exporting it from `lib.rs` makes the link resolve from the public API surface.

### clippy: unused variable `b` in test

`test_checked_div_with_strategy_zero_divisor` declared an outer `let b = ...` and then shadowed it inside two `#[cfg(...)]` branches. Under `--no-default-features` the outer `b` became unused. Split into two cfg-gated tests with separate scopes.

### Verification

- `cargo doc --no-deps --document-private-items --all-features` — zero warnings.
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — zero warnings.
- `make lint-fix pre-push` — clean across all feature configs.

## Semver impact

Additive. `DIV_ROUNDING_STRATEGY` is now part of the public API surface — it was meant to be since #23, but was effectively unreachable.

## Test plan

- [x] Full `make lint-fix pre-push` — clean.
- [x] Test matrix all green on default, no-default-features, non-zero.